### PR TITLE
Fix carousel

### DIFF
--- a/src/script.js
+++ b/src/script.js
@@ -3,42 +3,72 @@
 const btnLeft = document.getElementById("previous");
 const btnRight = document.getElementById("next");
 
-const slider = document.querySelector(".slider");
+// const slider = document.querySelector(".slider");
+const sliderContainer = document.querySelector(".slider-container");
 const slides = document.querySelectorAll(".slides");
 
-let currentSlide = 0;
-const maxSlide = slides.length;
+// let currentSlide = 0;
+// const maxSlide = slides.length;
 
-const goToSlide = function (slide) {
-  slides.forEach(
-    (s, i) => (s.style.transform = `translateX(${105 * (i - slide)}%)`)
-  );
-};
+// const goToSlide = function (slide) {
+//   slides.forEach(
+//     (s, i) => (s.style.transform = `translateX(${105 * (i - slide)}%)`)
+//   );
+// };
 
-goToSlide(0);
+// goToSlide(0);
 
-const nextSlide = function () {
-  if (currentSlide === maxSlide - 1) {
-    currentSlide = 0;
-  } else {
-    currentSlide++;
+// const nextSlide = function () {
+//   if (currentSlide === maxSlide - 1) {
+//     currentSlide = 0;
+//   } else {
+//     currentSlide++;
+//   }
+
+//   goToSlide(currentSlide);
+// };
+
+// const prevSlide = function () {
+//   if (currentSlide === 0) {
+//     currentSlide = maxSlide - 1;
+//   } else {
+//     currentSlide--;
+//   }
+
+//   goToSlide(currentSlide);
+// };
+
+function moveCarouselRight() {
+  const slideWidth = slides[0].clientWidth + 32;
+  // if at the end
+  if (sliderContainer.scrollLeft === sliderContainer.scrollLeftMax) {
+    sliderContainer.scrollLeft = 0;
   }
-
-  goToSlide(currentSlide);
-};
-
-const prevSlide = function () {
-  if (currentSlide === 0) {
-    currentSlide = maxSlide - 1;
-  } else {
-    currentSlide--;
+  // anywhere else
+  else {
+    const moveForwardValue =
+      (sliderContainer.scrollWidth -
+        (sliderContainer.scrollLeft + sliderContainer.clientWidth)) %
+        slideWidth || slideWidth;
+    sliderContainer.scrollLeft += moveForwardValue;
   }
+}
 
-  goToSlide(currentSlide);
-};
+function moveCarouselLeft() {
+  const slideWidth = slides[0].clientWidth + 32;
+  // if at the start
+  if (sliderContainer.scrollLeft === 0) {
+    sliderContainer.scrollLeft = sliderContainer.scrollLeftMax;
+  }
+  // anywhere else
+  else {
+    const moveBackValue = sliderContainer.scrollLeft % slideWidth || slideWidth;
+    sliderContainer.scrollLeft -= moveBackValue;
+  }
+}
 
-btnRight.addEventListener("click", nextSlide);
-btnLeft.addEventListener("click", prevSlide);
+btnRight.addEventListener("click", moveCarouselRight);
+btnLeft.addEventListener("click", moveCarouselLeft);
 
 // smooth reveal items on scroll
 const obeserver = new IntersectionObserver((entries) => {

--- a/src/scss/components/_slider.scss
+++ b/src/scss/components/_slider.scss
@@ -17,7 +17,10 @@
   }
 
   .slider-container {
-    overflow: hidden;
+    // overflow: hidden;
+    overflow-x: scroll;
+    max-width: fit-content;
+    margin: 0 auto;
 
     .slider {
       list-style: none;
@@ -25,14 +28,15 @@
       display: flex;
       align-items: center;
       justify-content: flex-start;
-      gap: 0.9375rem;
+      // gap: 0.9375rem;
+      gap: 32px;
       height: 17.5rem;
-      overflow-x: scroll;
+      // overflow-x: scroll;
       position: relative;
 
       @include responsive(phone-lg) {
         height: 23.75rem;
-        gap: 1.875rem;
+        // gap: 1.875rem;
       }
 
       .slides {
@@ -40,7 +44,7 @@
         max-width: 100%;
         display: inline-block;
         white-space: nowrap;
-        position: absolute;
+        // position: absolute;
         transition: transform 1s;
 
         .slides-img {


### PR DESCRIPTION
CSS Changes (_slider.scss):
- Move the scroll from the slider to the slider-container
- Center the slider-container
- Change silder gap to fixed value of 32px (for working with js)
- Remove position absolute on slides

JS Changes (script.js):
- Add slider-container querySelector
- Replace goToSlide, prevSlide and nextSlide with moveCarouselRight and moveCarouselLeft (these functions are changing the scroll values instead of transforming them using translateX)

The scroll behaviour is a little different now in that when moving right the right side of the carousel lines up evenly with the slides and when moving left the left side of the carousel lines up evenly with the slides. Before I believe it was on the left side both ways. Not an issue but just something you can experiment with further if you want :)